### PR TITLE
CHAT-226: Encoding issue with Juzu 1.0.0-cr2

### DIFF
--- a/application/src/main/java/org/exoplatform/chat/portlet/chat/ChatApplication.java
+++ b/application/src/main/java/org/exoplatform/chat/portlet/chat/ChatApplication.java
@@ -24,6 +24,7 @@ import juzu.Resource;
 import juzu.Response;
 import juzu.SessionScoped;
 import juzu.View;
+import juzu.impl.common.Tools;
 import juzu.plugin.ajax.Ajax;
 import juzu.request.SecurityContext;
 import juzu.template.Template;
@@ -150,7 +151,8 @@ public class ChatApplication
             .set("today", todayDate)
             .ok()
             .withMetaTag("viewport", "width=device-width, initial-scale=1.0")
-            .withAssets("chat-" + view);
+            .withAssets("chat-" + view)
+            .withCharset(Tools.UTF_8);
 
   }
 
@@ -216,7 +218,8 @@ public class ChatApplication
       saveSpaces(remoteUser_);
     }
 
-    return Response.ok(out).withMimeType("text/event-stream; charset=UTF-8").withHeader("Cache-Control", "no-cache");
+    return Response.ok(out).withMimeType("text/event-stream; charset=UTF-8").withHeader("Cache-Control", "no-cache")
+    		       .withCharset(Tools.UTF_8);
 
   }
 
@@ -258,7 +261,7 @@ public class ChatApplication
 
 
       return Response.ok(file.toJSON())
-              .withMimeType("application/json; charset=UTF-8").withHeader("Cache-Control", "no-cache");
+              .withMimeType("application/json; charset=UTF-8").withHeader("Cache-Control", "no-cache").withCharset(Tools.UTF_8);
     }
 
 
@@ -368,7 +371,8 @@ public class ChatApplication
     json.append("{ \"username\": \"").append(remoteUser_).append("\"");
     json.append(", \"token\": \"").append(token_).append("\" }");
 
-    return Response.ok(json).withMimeType("text/html; charset=UTF-8").withHeader("Cache-Control", "no-cache");
+    return Response.ok(json).withMimeType("text/html; charset=UTF-8").withHeader("Cache-Control", "no-cache")
+                   .withCharset(Tools.UTF_8);
   }
 
   protected void addUser(String remoteUser, String token)

--- a/application/src/main/java/org/exoplatform/chat/portlet/notification/BundleService.java
+++ b/application/src/main/java/org/exoplatform/chat/portlet/notification/BundleService.java
@@ -2,11 +2,13 @@ package org.exoplatform.chat.portlet.notification;
 
 import juzu.Resource;
 import juzu.Response;
+import juzu.impl.common.Tools;
 import juzu.plugin.ajax.Ajax;
 import juzu.request.ApplicationContext;
 import juzu.request.UserContext;
 
 import javax.enterprise.context.ApplicationScoped;
+
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Locale;
@@ -26,7 +28,8 @@ public class BundleService {
   {
     Locale locale = userContext.getLocale();
     ResourceBundle bundle= applicationContext.resolveBundle(locale) ;
-    return Response.ok(getBundle(target, bundle, locale)).withMimeType("text/javascript; charset=UTF-8").withHeader("Cache-Control", "no-cache");
+    return Response.ok(getBundle(target, bundle, locale)).withMimeType("text/javascript; charset=UTF-8").withHeader("Cache-Control", "no-cache")
+                   .withCharset(Tools.UTF_8);
   }
 
   public String getBundle(String target, ResourceBundle bundle, Locale locale) {

--- a/application/src/main/java/org/exoplatform/chat/portlet/notification/NotificationApplication.java
+++ b/application/src/main/java/org/exoplatform/chat/portlet/notification/NotificationApplication.java
@@ -24,11 +24,13 @@ import juzu.Resource;
 import juzu.Response;
 import juzu.SessionScoped;
 import juzu.View;
+import juzu.impl.common.Tools;
 import juzu.plugin.ajax.Ajax;
 import juzu.request.ApplicationContext;
 import juzu.request.SecurityContext;
 import juzu.request.UserContext;
 import juzu.template.Template;
+
 import org.apache.commons.lang.StringUtils;
 import org.exoplatform.chat.listener.ServerBootstrap;
 import org.exoplatform.chat.model.SpaceBean;
@@ -50,6 +52,7 @@ import org.exoplatform.social.core.space.spi.SpaceService;
 import javax.inject.Inject;
 import javax.inject.Provider;
 import javax.portlet.PortletPreferences;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -116,7 +119,8 @@ public class NotificationApplication
             .set("messages", messages)
             .set("shortSpaceName", shortSpaceName)
             .set("sessionId", Util.getPortalRequestContext().getRequest().getSession().getId())
-            .ok();
+            .ok()
+            .withCharset(Tools.UTF_8);
   }
 
   @Ajax
@@ -157,7 +161,8 @@ public class NotificationApplication
       saveSpaces(remoteUser_);
     }
 
-    return Response.ok(out).withMimeType("text/event-stream; charset=UTF-8").withHeader("Cache-Control", "no-cache");
+    return Response.ok(out).withMimeType("text/event-stream; charset=UTF-8").withHeader("Cache-Control", "no-cache")
+                   .withCharset(Tools.UTF_8);
 
   }
 

--- a/server/src/main/java/org/exoplatform/chat/server/ChatServer.java
+++ b/server/src/main/java/org/exoplatform/chat/server/ChatServer.java
@@ -22,13 +22,16 @@ package org.exoplatform.chat.server;
 import com.mongodb.BasicDBList;
 import com.mongodb.BasicDBObject;
 import com.mongodb.util.JSON;
+
 import juzu.MimeType;
 import juzu.Path;
 import juzu.Resource;
 import juzu.Response;
 import juzu.Route;
 import juzu.View;
+import juzu.impl.common.Tools;
 import juzu.template.Template;
+
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.exoplatform.chat.listener.GuiceManager;
@@ -60,10 +63,10 @@ import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeBodyPart;
 import javax.mail.internet.MimeMessage;
 import javax.mail.internet.MimeMultipart;
+
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
-import java.nio.charset.Charset;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -129,8 +132,8 @@ public class ChatServer
 
     RoomsBean roomsBean = chatService.getRooms(user, filter, true, true, false, true, "true".equals(isAdmin), ilimit,
             notificationService, userService, tokenService);
-    return Response.ok(roomsBean.roomsToJSON()).withMimeType("application/json; charset=UTF-8").withHeader
-            ("Cache-Control", "no-cache");
+    return Response.ok(roomsBean.roomsToJSON()).withMimeType("application/json").withHeader
+            ("Cache-Control", "no-cache").withCharset(Tools.UTF_8);
   }
 
   @Resource
@@ -234,7 +237,8 @@ public class ChatServer
 
     String data = chatService.read(room, userService, "true".equals(isTextOnly), from);
 
-    return Response.ok(data).withMimeType("application/json; charset=UTF-8").withHeader("Cache-Control", "no-cache");
+    return Response.ok(data).withMimeType("application/json").withHeader("Cache-Control", "no-cache")
+                   .withCharset(Tools.UTF_8);
   }
 
   @Resource
@@ -416,7 +420,8 @@ public class ChatServer
       }
     }
 
-    return Response.ok(jsonObject.toString()).withMimeType("application/json; charset=UTF-8").withHeader("Cache-Control", "no-cache");
+    return Response.ok(jsonObject.toString()).withMimeType("application/json").withHeader("Cache-Control", "no-cache")
+                   .withCharset(Tools.UTF_8);
   }
 
   @Resource
@@ -568,7 +573,7 @@ public class ChatServer
       out = roomBean.toJSON();
     }
 
-    return Response.ok(out).withMimeType("application/json; charset=UTF-8").withHeader("Cache-Control", "no-cache");
+    return Response.ok(out).withMimeType("application/json").withCharset(Tools.UTF_8).withHeader("Cache-Control", "no-cache");
   }
 
   @Resource
@@ -671,7 +676,8 @@ public class ChatServer
       LOG.warning(e.getMessage());
       return Response.notFound("No Room yet");
     }
-    return Response.ok(jsonObject.toString()).withMimeType("application/json; charset=UTF-8").withHeader("Cache-Control", "no-cache");
+    return Response.ok(jsonObject.toString()).withMimeType("application/json").withHeader("Cache-Control", "no-cache")
+                   .withCharset(Tools.UTF_8);
   }
 
   @Resource
@@ -738,7 +744,7 @@ public class ChatServer
       data += "data: {\"total\": "+totalUnread+"}\n\n";
     }
 
-    return Response.ok(data).withMimeType("application/json").withCharset(Charset.forName("UTF-8")).withHeader("Cache-Control", "no-cache");
+    return Response.ok(data).withMimeType("application/json").withCharset(Tools.UTF_8).withHeader("Cache-Control", "no-cache");
   }
 
   @Resource
@@ -846,8 +852,8 @@ public class ChatServer
 
     UsersBean usersBean = new UsersBean();
     usersBean.setUsers(users);
-    return Response.ok(usersBean.usersToJSON()).withMimeType("application/json; charset=UTF-8").withHeader
-            ("Cache-Control", "no-cache");
+    return Response.ok(usersBean.usersToJSON()).withMimeType("application/json").withHeader
+            ("Cache-Control", "no-cache").withCharset(Tools.UTF_8);
   }
 
   @Resource
@@ -863,7 +869,7 @@ public class ChatServer
     data.append(" \"notificationsUnread\": "+notificationService.getNumberOfUnreadNotifications());
     data.append("}");
 
-    return Response.ok(data.toString()).withMimeType("application/json; charset=UTF-8").withHeader("Cache-Control", "no-cache");
+    return Response.ok(data.toString()).withMimeType("application/json").withCharset(Tools.UTF_8).withHeader("Cache-Control", "no-cache");
   }
 
   public void sendMailWithAuth(String senderFullname, List<String> toList, String htmlBody, String subject) throws Exception {

--- a/server/src/main/java/org/exoplatform/chat/server/ChatTools.java
+++ b/server/src/main/java/org/exoplatform/chat/server/ChatTools.java
@@ -30,6 +30,7 @@ import javax.enterprise.context.ApplicationScoped;
 import juzu.Resource;
 import juzu.Response;
 import juzu.Route;
+import juzu.impl.common.Tools;
 
 import org.exoplatform.chat.listener.ConnectionManager;
 import org.exoplatform.chat.listener.GuiceManager;
@@ -86,7 +87,7 @@ public class ChatTools
     data.append(" \"user\": \""+ username+"\" ");
     data.append("}");
 
-    return Response.ok(data.toString()).withMimeType("text/event-stream; charset=UTF-8").withHeader("Cache-Control", "no-cache");
+    return Response.ok(data.toString()).withMimeType("text/event-stream").withCharset(Tools.UTF_8).withHeader("Cache-Control", "no-cache");
   }
 
   @Resource
@@ -138,7 +139,7 @@ public class ChatTools
     data.append(" \"user\": \""+ username+"\" ");
     data.append("}");
 
-    return Response.ok(data.toString()).withMimeType("text/event-stream; charset=UTF-8").withHeader("Cache-Control", "no-cache");
+    return Response.ok(data.toString()).withMimeType("text/event-stream").withCharset(Tools.UTF_8).withHeader("Cache-Control", "no-cache");
   }
 
   @Resource
@@ -152,7 +153,7 @@ public class ChatTools
 
     tokenService.addUser(username, token);
 
-    return Response.ok("OK").withMimeType("text/event-stream; charset=UTF-8").withHeader("Cache-Control", "no-cache");
+    return Response.ok("OK").withMimeType("text/event-stream").withCharset(Tools.UTF_8).withHeader("Cache-Control", "no-cache");
   }
 
   @Resource
@@ -220,7 +221,7 @@ public class ChatTools
 
     String fullname = userService.getUserFullName(username);
 
-    return Response.ok(String.valueOf(fullname)).withMimeType("text/event-stream; charset=UTF-8").withHeader("Cache-Control", "no-cache");
+    return Response.ok(String.valueOf(fullname)).withMimeType("text/event-stream").withCharset(Tools.UTF_8).withHeader("Cache-Control", "no-cache");
   }
 
   @Resource
@@ -275,7 +276,7 @@ public class ChatTools
     data.append(" \"message\": \"using db="+db+"\"");
     data.append("}");
 
-    return Response.ok(data.toString()).withMimeType("text/event-stream; charset=UTF-8").withHeader("Cache-Control", "no-cache");
+    return Response.ok(data.toString()).withMimeType("text/event-stream").withCharset(Tools.UTF_8).withHeader("Cache-Control", "no-cache");
   }
 
   @Resource
@@ -299,7 +300,7 @@ public class ChatTools
     data.append(" \"message\": \"deleting db="+db+"\"");
     data.append("}");
 
-    return Response.ok(data.toString()).withMimeType("text/event-stream; charset=UTF-8").withHeader("Cache-Control", "no-cache");
+    return Response.ok(data.toString()).withMimeType("text/event-stream").withCharset(Tools.UTF_8).withHeader("Cache-Control", "no-cache");
   }
 
   @Resource
@@ -328,7 +329,7 @@ public class ChatTools
     data.append(" \"message\": \"indexes created or updated on db="+db+"\"");
     data.append("}");
 
-    return Response.ok(data.toString()).withMimeType("text/event-stream; charset=UTF-8").withHeader("Cache-Control", "no-cache");
+    return Response.ok(data.toString()).withMimeType("text/event-stream").withCharset(Tools.UTF_8).withHeader("Cache-Control", "no-cache");
   }
 
 


### PR DESCRIPTION
Problem analysis:
* Juzu 1.0.0-cr2 uses the default character encoding of Latin1 (ISO-8859).
  It breaks then all responses containing characters outside that character set.

Fix description:
* Set explicitly UTF-8 for responses which might contain non-Latin1 characters:
** user's First/Last Name
** Team Name
** Space Name
** Event/Task
** File name