### PR TITLE
CHAT-269: [Save meeting notes in Wiki] Missing non-ASCII characters i…

### DIFF
--- a/application/src/main/java/org/exoplatform/chat/portlet/chat/ChatApplication.java
+++ b/application/src/main/java/org/exoplatform/chat/portlet/chat/ChatApplication.java
@@ -349,7 +349,7 @@ public class ChatApplication
     path = ServerBootstrap.getServerBase()+path;
 
     return Response.ok("{\"status\":\"ok\", \"path\":\""+path+"\"}")
-            .withMimeType("application/json; charset=UTF-8").withHeader("Cache-Control", "no-cache");
+            .withMimeType("application/json; charset=UTF-8").withHeader("Cache-Control", "no-cache").withCharset(Tools.UTF_8);
 
   }
 


### PR DESCRIPTION
…n wiki's link

Problem analysis:
* Juzu 1.0.0 uses the default character encoding as Latin1 (ISO-8859-1). It breaks non-ASCII characters in Juzu's response.
* ChatApplication.saveWiki has the response with the wiki path. In case of 1:1 or team chat, this path might contain non-ASCII characters.

Fix description:
* Set UTF-8 as the character encoding for the response.