### PR TITLE
PLF-6493 [Profile Page] Buttons Connect/disconnect and Chat in user profile acting strangely

### DIFF
--- a/application/src/main/webapp/js/notif.js
+++ b/application/src/main/webapp/js/notif.js
@@ -600,6 +600,18 @@ ChatNotification.prototype.attachChatToProfile = function() {
             }
         });
 
+        // Fix PLF-6493: Only let hover happens on connection buttons instead of all in .user-actions
+        var $btnConnections = jqchat(".show-default, .hide-default", $userActions);
+        var $btnShowConnection = jqchat(".show-default", $userActions);
+        var $btnHideConnection = jqchat(".hide-default", $userActions);
+        $btnShowConnection.show();
+        $btnConnections.css('font-style', 'italic');
+        $btnHideConnection.hide();
+        $btnConnections.removeClass('show-default hide-default');
+        $btnConnections.hover(function(e) {
+          $btnConnections.toggle();
+        });
+
         function cbGetStatus(targetUser, status) {
             if (status !== "offline") {
                 jqchat(".chatPopup-" + targetUser.replace('.', '-')).removeClass("disabled");


### PR DESCRIPTION

Analysis: css of user-actions class effects all elements inside when hovering
Solution: Use javascript to let hover only to work on buttons