### PR TITLE
CHAT-369 : do not scroll down to bottom automaticaly when scrolling the messages

### DIFF
--- a/application/src/main/webapp/js/chat-modules.js
+++ b/application/src/main/webapp/js/chat-modules.js
@@ -72,7 +72,11 @@ ChatRoom.prototype.init = function(username, token, targetUser, targetFullname, 
       jzStoreParam("lastTS"+thiss.username, "0");
       thiss.chatEventInt = window.clearInterval(thiss.chatEventInt);
       thiss.chatEventInt = setInterval(jqchat.proxy(thiss.refreshChat, thiss), thiss.chatIntervalChat);
-      thiss.refreshChat(true);
+      thiss.refreshChat(true, function() {
+        // always scroll to the last message when loading a chat room
+        var $chats = jqchat("#chats");
+        $chats.scrollTop($chats.prop('scrollHeight') - $chats.innerHeight());
+      });
     }
   });
 
@@ -1141,7 +1145,8 @@ function maximizeMiniChat() {
   $miniChat.find(".notify-info").hide();
   $history.show("fast");
   $miniChat.find(".message").show("fast");
-  $history.animate({ scrollTop: 20000 }, 'fast');
+  // scroll to the last message
+  $history.scrollTop($history.prop('scrollHeight') - $history.innerHeight());
 
   $miniChat.show("fast", function() {
     $miniChat.find(".message-input").focus();
@@ -1245,9 +1250,19 @@ function showMiniChatPopup(room, type) {
       });
       miniChats[index].onShowMessages(function(out) {
         var $history = this.miniChat.find(".history");
+
+        // check if scroll was at max before the new message
+        var scrollTopMax = $history.prop('scrollHeight') - $history.innerHeight();
+        var scrollAtMax = ($history.scrollTop() == scrollTopMax);
+
         $history.html('<span>'+out+'</span>');
         var totalMsgs = jqchat(".msUserCont", $history).length;
-        $history.animate({ scrollTop: 20000 }, 'fast');
+
+        // if scroll was at max, scroll to the new max to display the new message. Otherwise don't move the scroll.
+        if (scrollAtMax) {
+          var newScrollTopMax = $history.prop('scrollHeight') - $history.innerHeight();
+          $history.scrollTop(newScrollTopMax);
+        }
 
         if ($history.is(":hidden")) {
           var unreadTotal = totalMsgs - $miniChat.attr("readTotal");

--- a/application/src/main/webapp/js/chat.js
+++ b/application/src/main/webapp/js/chat.js
@@ -2105,9 +2105,16 @@ ChatApplication.prototype.onRefreshCallback = function(code) {
 ChatApplication.prototype.onShowMessagesCallback = function(out) {
 
   var $chats = jqchat("#chats");
-  $chats.html('<span>'+out+'</span>');
+  // check if scroll was at max before the new message
+  var scrollTopMax = $chats.prop('scrollHeight') - $chats.innerHeight();
+  var scrollAtMax = ($chats.scrollTop() == scrollTopMax);
+  $chats.html('<span>' + out + '</span>');
   sh_highlightDocument();
-  $chats.scrollTop(20000);
+  // if scroll was at max, scroll to the new max to display the new message. Otherwise don't move the scroll.
+  if (scrollAtMax) {
+    var newScrollTopMax = $chats.prop('scrollHeight') - $chats.innerHeight();
+    $chats.scrollTop(newScrollTopMax);
+  }
 
   jqchat(".msg-text").mouseover(function() {
     if (jqchat(".msg-actions", this).children().length > 0) {


### PR DESCRIPTION
This PR adds the following behaviors :
* when the scroll is at the bottom of a room (last message shown) and a new message is received, the new message is displayed
* when the scroll is not at the bottom of a room and a new message is received, the scroll does not move and the new message is not shown
* when switching from one room to another one, always scroll down to the last message

This fix has been tested on Chrome and Firefox, but not yet on IE/Edge. If a reviewer can do that for me, I'll owe him/her a beer ;-)
