### PR TITLE
CHAT-378 : do not load room when clicking on the room's name in the menu

### DIFF
--- a/application/src/main/webapp/js/chat.js
+++ b/application/src/main/webapp/js/chat.js
@@ -2527,18 +2527,6 @@ ChatApplication.prototype.jQueryForUsersTemplate = function() {
     $uiIconChatFavorite.css("display", "none");
   });
 
-
-  jqchat('.room-link').on("click", function() {
-    thiss.targetUser = jqchat(this).attr("user-data");
-    thiss.targetFullname = jqchat(this).attr("data-fullname");
-    thiss.loadRoom();
-    if (thiss.isMobileView()) {
-      jqchat(".uiRightContainerArea").css("display", "block");
-      jqchat(".uiLeftContainerArea").css("display", "none");
-//      jqchat(".room-name").html(thiss.targetFullname);
-    }
-  });
-
   jqchat('.user-status').on("click", function() {
     var targetFav = jqchat(this).attr("user-data");
     thiss.toggleFavorite(targetFav);


### PR DESCRIPTION
The room is loaded on 2 events : when clicking on the name of the room in the menu and when clicking on the menu line in the menu. Since the room name is inside the menu line, the 2 events are triggered, so the room is loaded 2 times.
This PR removes the load when clicking on the room's name.