### PR TITLE
CHAT-368 : decode Rooms labels on the room list

### DIFF
--- a/application/src/main/java/org/exoplatform/chat/portlet/notification/package-info.java
+++ b/application/src/main/java/org/exoplatform/chat/portlet/notification/package-info.java
@@ -29,7 +29,7 @@
         @Script(value = "js/jquery-1.8.3.min.js", id = "jquery", location = AssetLocation.SERVER),
         @Script(value = "js/taffy-min.js", id="taffy", location = AssetLocation.SERVER),
         @Script(value = "js/snack-min.js", id = "snack", location = AssetLocation.SERVER),
-        @Script(value = "js/jquery-juzu-utils-0.1.0.js", depends = "jquery", id = "juzu-utils", location = AssetLocation.SERVER),
+        @Script(value = "js/jquery-juzu-utils-0.2.0.js", depends = "jquery", id = "juzu-utils", location = AssetLocation.SERVER),
         @Script(value = "js/notif.js", id = "notif", location = AssetLocation.SERVER, depends = {"jquery", "snack", "juzu-utils", "taffy"})
 })
 @Stylesheets({

--- a/application/src/main/webapp/js/chat.js
+++ b/application/src/main/webapp/js/chat.js
@@ -2053,7 +2053,7 @@ ChatApplication.prototype.getRoomHtml = function(room, roomPrevUser) {
     out += '</td>';
     out +=  '<td>';
     if (room.isActive=="true") {
-      out += '<span user-data="'+room.user+'" room-data="'+room.room+'" class="room-link" data-fullname="'+room.escapedFullname+'">'+room.escapedFullname+'</span>';
+      out += '<span user-data="'+room.user+'" room-data="'+room.room+'" class="room-link" data-fullname="'+room.escapedFullname+'">'+ decodeRoomName(room.escapedFullname) +'</span>';
     } else {
       out += '<span class="room-inactive muted">'+room.user+'</span>';
     }

--- a/application/src/main/webapp/js/jquery-juzu-utils-0.2.0.js
+++ b/application/src/main/webapp/js/jquery-juzu-utils-0.2.0.js
@@ -246,3 +246,11 @@ function calcMD5(str)
   return rhex(a) + rhex(b) + rhex(c) + rhex(d);
 }
 
+/**
+ * Take a string and replace some html entities by their corresponding characters
+ * @param str the string to decode
+ * @returns the decoded string
+ */
+function decodeRoomName(str) {
+  return str.replace(/&amp;/gi, '&').replace(/&gt;/gi, '>').replace(/&lt;/gi, '<');
+}


### PR DESCRIPTION
I fixed this issue in a simpler manner to avoid too big refactoring or the use of another third party library (like https://github.com/mathiasbynens/he).
I renamed the `jquery-juzu-utils-0.1.0.js` to avoid the need of browser refresh for the end user.

This fix correctly decode the following characters in the Team Room label : 
* `&amp;` => `&`
* `&gt;` => `>`
* `&lt;` => `<`
