### PR TITLE
CHAT-345 : upgrade java driver to 3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <commons-lang3.version>3.2</commons-lang3.version>
     <javax.enterprise.cdi.version>1.0-SP4</javax.enterprise.cdi.version>
     <juzu.version>1.1.0</juzu.version>
-    <mongodb-java-driver.version>2.14.0</mongodb-java-driver.version>
+    <mongodb-java-driver.version>3.2.2</mongodb-java-driver.version>
     <!-- **************************************** -->
     <!-- Jenkins Settings -->
     <jenkins.job.name>chat-application-develop-ci</jenkins.job.name>

--- a/server/src/main/java/org/exoplatform/chat/services/mongodb/ChatServiceImpl.java
+++ b/server/src/main/java/org/exoplatform/chat/services/mongodb/ChatServiceImpl.java
@@ -135,7 +135,7 @@ public class ChatServiceImpl implements org.exoplatform.chat.services.ChatServic
       dbo.put("message", TYPE_DELETED);
       dbo.put("type", TYPE_DELETED);
       dbo.put("lastUpdatedTimestamp", System.currentTimeMillis());
-      coll.save(dbo, WriteConcern.NONE);
+      coll.save(dbo, WriteConcern.UNACKNOWLEDGED);
     }
   }
 
@@ -222,7 +222,7 @@ public class ChatServiceImpl implements org.exoplatform.chat.services.ChatServic
       dbo.put("message", message);
       dbo.put("type", TYPE_EDITED);
       dbo.put("lastUpdatedTimestamp", System.currentTimeMillis());
-      coll.save(dbo, WriteConcern.NONE);
+      coll.save(dbo, WriteConcern.UNACKNOWLEDGED);
     }
   }
 
@@ -393,7 +393,7 @@ public class ChatServiceImpl implements org.exoplatform.chat.services.ChatServic
     {
       DBObject dbo = cursor.next();
       dbo.put("timestamp", System.currentTimeMillis());
-      coll.save(dbo, WriteConcern.NONE);
+      coll.save(dbo, WriteConcern.UNACKNOWLEDGED);
     }
 
   }
@@ -520,7 +520,7 @@ public class ChatServiceImpl implements org.exoplatform.chat.services.ChatServic
 
     return creator;
   }
-  
+
   public void setRoomName(String room, String name, String dbName) {
     DBCollection coll = db(dbName).getCollection(M_ROOMS_COLLECTION);
 
@@ -532,7 +532,7 @@ public class ChatServiceImpl implements org.exoplatform.chat.services.ChatServic
     {
       DBObject dbo = cursor.next();
       dbo.put("team", name);
-      coll.save(dbo, WriteConcern.NONE);
+      coll.save(dbo, WriteConcern.UNACKNOWLEDGED);
     }
   }
 


### PR DESCRIPTION
This PR upgrades to Java driver 3.2. It replaces the deprecated Mongo client class by the new one MongoClient.

I have a doubt about authentication mechanism. It has changed since 3.0 in the Java driver. Now the authentication credentials must be passed at the creation of the MongoClient object, whereas it was done on db fetch in the previous versions.