### PR TITLE
First basic version of a Chat desktop app built with Electron

### DIFF
--- a/exo-addons-chat-desktop-app/main.js
+++ b/exo-addons-chat-desktop-app/main.js
@@ -1,0 +1,47 @@
+const electron = require('electron')
+// Module to control application life.
+const app = electron.app
+// Module to create native browser window.
+const BrowserWindow = electron.BrowserWindow
+
+// Keep a global reference of the window object, if you don't, the window will
+// be closed automatically when the JavaScript object is garbage collected.
+let mainWindow
+
+function createWindow () {
+  // Create the browser window.
+  mainWindow = new BrowserWindow({width: 1200, height: 850})
+
+  // and load the index.html of the app.
+  mainWindow.loadURL('https://community.exoplatform.com/portal/intranet/chat')
+
+  // Emitted when the window is closed.
+  mainWindow.on('closed', function () {
+    // Dereference the window object, usually you would store windows
+    // in an array if your app supports multi windows, this is the time
+    // when you should delete the corresponding element.
+    mainWindow = null
+  })
+}
+
+// This method will be called when Electron has finished
+// initialization and is ready to create browser windows.
+// Some APIs can only be used after this event occurs.
+app.on('ready', createWindow)
+
+// Quit when all windows are closed.
+app.on('window-all-closed', function () {
+  // On OS X it is common for applications and their menu bar
+  // to stay active until the user quits explicitly with Cmd + Q
+  if (process.platform !== 'darwin') {
+    app.quit()
+  }
+})
+
+app.on('activate', function () {
+  // On OS X it's common to re-create a window in the app when the
+  // dock icon is clicked and there are no other windows open.
+  if (mainWindow === null) {
+    createWindow()
+  }
+})

--- a/exo-addons-chat-desktop-app/package.json
+++ b/exo-addons-chat-desktop-app/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "exo-chat",
+  "version": "1.0.0",
+  "description": "eXo Chat",
+  "main": "main.js",
+  "scripts": {
+    "start": "electron main.js",
+    "build": "electron-packager . --out=dist --app-version=$npm_package_version --prune --asar --overwrite --platform=linux,darwin --arch=x64"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:exo-addons/chat-application.git"
+  },
+  "author": "eXoPlatform",
+  "license": "LGPL-3.0",
+  "homepage": "https://github.com/exo-addons/chat-application",
+  "devDependencies": {
+    "electron-packager": "^7.0.0",
+    "electron-prebuilt": "^1.0.1"
+  }
+}


### PR DESCRIPTION
New module to build a desktop app with Electron for the Chat.
It is very basic for the moment and simply loads the Tribe Chat.
To test (in exo-addons-chat-desktop-app folder) :
- install npm dependencies : npm install
- launch directly the app from the sources : npm start
- build native versions for linux and osx (in dist folder) : npm run build
