### PR TITLE
CHAT-420 : display message when message content is empty but type is defined (case of meeting start and end messages)

### DIFF
--- a/application/src/main/webapp/js/chat-modules.js
+++ b/application/src/main/webapp/js/chat-modules.js
@@ -103,8 +103,9 @@ ChatRoom.prototype.onShowMessages = function(callback) {
 };
 
 ChatRoom.prototype.sendMessage = function(msg, options, isSystemMessage, callback) {
-  if(msg.trim().length!=0)
+  if(msg.trim().length != 0 || options.type) {
     this.sendFullMessage(this.username, this.token, this.targetUser, this.id, msg, options, isSystemMessage, callback);
+  }
 };
 
 /**


### PR DESCRIPTION
This PR add a chek on the message type. If it is defined, the message is displayed. This is the case for meeting start and end messages.