### PR TITLE
CHAT-463 : do not empty the html of the room users panel before updating it + update the panel only if there were changes in the room users list

### DIFF
--- a/application/src/main/webapp/js/chat-modules.js
+++ b/application/src/main/webapp/js/chat-modules.js
@@ -30,6 +30,7 @@ function ChatRoom(jzChatRead, jzChatSend, jzChatGetRoom, jzChatUpdateUnreadMessa
   this.targetFullname = "";
   this.isPublic = isPublic;
   this.miniChat = undefined;
+  this.users = [];
 
   this.ANONIM_USER = "__anonim_";
 


### PR DESCRIPTION
This PR avoids the blink effect on room users panel when not emptying the html before updating it. It also improves the update by checking if there have been changes in the users list and updates the DOM only it there have been changes.