### PR TITLE
CHAT-507 : set the right target room to load it correctly and hide the right panel in case of 1:1 rooms

### DIFF
--- a/application/src/main/webapp/js/notif.js
+++ b/application/src/main/webapp/js/notif.js
@@ -455,8 +455,16 @@ ChatNotification.prototype.showDesktopNotif = function(path, nbrNotif, msg) {
        displayTitle = msg.roomDisplayName;
       }
 
-      localStorage.setItem('eXoChat.targetUser',"team-"+msg.categoryId);
-      localStorage.setItem('eXoChat.targetFullname',displayTitle);
+      var targetUser;
+      if(msg.roomType === 't') {
+        targetUser = "team-" + msg.categoryId;
+      } else if(msg.roomType === 's') {
+        targetUser = "space-" + msg.categoryId;
+      } else {
+        targetUser = msg.from;
+      }
+      localStorage.setItem('eXoChat.targetUser', targetUser);
+      localStorage.setItem('eXoChat.targetFullname', displayTitle);
 
       if(typeof chatApplication === "undefined") {
         newTab = window.open(path);

--- a/server/src/main/java/org/exoplatform/chat/model/NotificationBean.java
+++ b/server/src/main/java/org/exoplatform/chat/model/NotificationBean.java
@@ -38,6 +38,7 @@ public class NotificationBean {
   private String categoryId;
   private String options = StringUtils.EMPTY;
   private String roomDisplayName = StringUtils.EMPTY;
+  private String roomType;
   private Long timestamp;
 
   public String getUser() {
@@ -116,9 +117,18 @@ public class NotificationBean {
     return roomDisplayName;
   }
 
+  public void setRoomType(String roomType) {
+    this.roomType = roomType;
+  }
+
+  public String getRoomType() {
+    return roomType;
+  }
+
   public void setRoomDisplayName(String roomDisplayName) {
     this.roomDisplayName = roomDisplayName;
   }
+
 
   public String getFromFullName() {
     return fromFullName;
@@ -152,6 +162,7 @@ public class NotificationBean {
         obj.put("options", StringUtils.EMPTY);
       }
       obj.put("roomDisplayName", StringEscapeUtils.escapeHtml4(this.getRoomDisplayName()));
+      obj.put("roomType", this.getRoomType());
       obj.put("timestamp", this.getTimestamp());
 
     } catch (JSONException e) {

--- a/server/src/main/java/org/exoplatform/chat/model/RoomBean.java
+++ b/server/src/main/java/org/exoplatform/chat/model/RoomBean.java
@@ -32,6 +32,7 @@ public class RoomBean implements Comparable<RoomBean>
   int unreadTotal = -1;
   boolean isAvailableUser = false;
   String status = UserService.STATUS_INVISIBLE;
+  String type = null;
   boolean isSpace = false;
   boolean isTeam = false;
   boolean isFavorite = false;
@@ -91,6 +92,14 @@ public class RoomBean implements Comparable<RoomBean>
 
   public void setStatus(String status) {
     this.status = status;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public void setType(String type) {
+    this.type = type;
   }
 
   public boolean isSpace() {

--- a/server/src/main/java/org/exoplatform/chat/services/mongodb/NotificationServiceImpl.java
+++ b/server/src/main/java/org/exoplatform/chat/services/mongodb/NotificationServiceImpl.java
@@ -163,6 +163,7 @@ public class NotificationServiceImpl implements org.exoplatform.chat.services.No
         notificationBean.setOptions(doc.get("options").toString());
       }
       RoomBean roomBean = userService.getRoom(user, notificationBean.getCategoryId(), dbName);
+      notificationBean.setRoomType(roomBean.getType());
       if (roomBean.isSpace() || roomBean.isTeam()) {
         notificationBean.setRoomDisplayName(roomBean.getFullname());
       }

--- a/server/src/main/java/org/exoplatform/chat/services/mongodb/UserServiceImpl.java
+++ b/server/src/main/java/org/exoplatform/chat/services/mongodb/UserServiceImpl.java
@@ -23,10 +23,7 @@ import com.mongodb.*;
 
 import org.apache.commons.lang3.StringUtils;
 import org.exoplatform.chat.listener.ConnectionManager;
-import org.exoplatform.chat.model.NotificationSettingsBean;
-import org.exoplatform.chat.model.RoomBean;
-import org.exoplatform.chat.model.SpaceBean;
-import org.exoplatform.chat.model.UserBean;
+import org.exoplatform.chat.model.*;
 import org.exoplatform.chat.services.ChatService;
 import org.exoplatform.chat.services.UserService;
 import org.exoplatform.chat.utils.ChatUtils;
@@ -548,6 +545,7 @@ public class UserServiceImpl implements org.exoplatform.chat.services.UserServic
         roomBean.setTimestamp(((Long) doc.get("timestamp")).longValue());
       }
       String type = doc.get("type").toString();
+      roomBean.setType(type);
       if ("s".equals(type))
       {
         roomBean.setUser(ChatService.SPACE_PREFIX+roomId);


### PR DESCRIPTION
Instead of harcoding the target room as a team room, the room type is now read to set the right target room identifier.
