### PR TITLE
CHAT-563 : Cannot edit a room

### DIFF
--- a/application/src/main/webapp/js/chat.js
+++ b/application/src/main/webapp/js/chat.js
@@ -2460,6 +2460,8 @@ ChatApplication.prototype.loadRoom = function() {
   var thiss = this;
   this.chatRoom.owner = "";
   if (this.targetUser!==undefined) {
+    // hide admin actions - we need to check if the current is the admin of the room before displaying them
+    jqchat("#chat-team-button-dropdown .only-admin").hide();
     // reset room users panel
     this.chatRoom.users = [];
     jqchat("#room-users-list").html("");
@@ -2552,7 +2554,6 @@ ChatApplication.prototype.loadRoom = function() {
             jqchat("#chat-team-button-dropdown").show();
             jqchat("#userRoomStatus").hide();
           } else {
-            jqchat("#chat-team-button-dropdown .only-admin").hide();
             jqchat("#userRoomStatus").removeClass("hide").show();
           }
         },
@@ -3542,7 +3543,6 @@ ChatApplication.prototype.displayVideoCallOnChatApp = function () {
  */
 ChatApplication.prototype.loadRoomUsers = function() {
   var thiss = this;
-  this.chatRoom.owner = "";
   var roomUsersContainer = jqchat(".uiRoomUsersContainerArea");
   if (this.targetUser !== undefined) {
     roomUsersContainer.show();


### PR DESCRIPTION
This PR :
* hides the admin actions in the drop down menu as soon as a room is loaded to make sure admin actions are not visible by anyone, even temporarily
* removes the reset of the room creator when loading room users since it is useless and prevents from displaying the room edition popup