### PR TITLE
CHAT-559 : remove space between input field and suggetion list + improve suggestion list width

### DIFF
--- a/application/src/main/java/org/exoplatform/chat/portlet/chat/assets/base.less
+++ b/application/src/main/java/org/exoplatform/chat/portlet/chat/assets/base.less
@@ -419,10 +419,10 @@ table.list-rooms {
 
 .team-users-search {
   margin-top: 5px;
-   .team-add-user-label {
-    margin-top: 10px;
-  }
-
+}
+.team-add-user-label {
+  display: block;
+  margin-top: 5px;
 }
 .team-user-logo, .task-user-logo {
   margin: 2px 10px 0 -100%;
@@ -437,9 +437,9 @@ table.list-rooms {
   }
 }
 .team-users-results, .task-users-results {
-  margin-top: -36px;
   left: auto;
   top: auto;
+  min-width: 270px;
   max-height: 173px;
   overflow: auto;
   .team-user, .task-user {
@@ -451,7 +451,6 @@ table.list-rooms {
       white-space: nowrap;
       > .inner {
         margin-left: 26px;
-        margin-right: 26px;
         display: block;
       }
     }

--- a/application/src/main/java/org/exoplatform/chat/portlet/chat/templates/index.gtmpl
+++ b/application/src/main/java/org/exoplatform/chat/portlet/chat/templates/index.gtmpl
@@ -399,10 +399,10 @@
         <div class="uiSearchForm uiSearchInput team-users-search">
           <div onclick="event.cancelBubble=true;">
             <input id="team-add-user" type="text" >
-            <label class="team-add-user-label">&{exoplatform.chat.team.help}</label>
           </div>
         </div>
         <div class="team-users-results uiAutoComplete" style="display:none;"></div>
+        <span class="team-add-user-label">&{exoplatform.chat.team.help}</span>
       </div>
     </div>
     <div class="uiAction uiActionBorder">


### PR DESCRIPTION
This PR removes the space between the input field and the suggestion list and change the width of the suggestion list. I change the min-width of this list to match with the input field, but I kept the variable width since I think it is better to not cut long user names.