### PR TITLE
CHAT-582 : increase default polling intervals to reduce server load

### DIFF
--- a/application/src/main/java/org/exoplatform/chat/portlet/notification/NotificationApplication.java
+++ b/application/src/main/java/org/exoplatform/chat/portlet/notification/NotificationApplication.java
@@ -100,6 +100,7 @@ public class NotificationApplication
     String chatServerURL = PropertyManager.getProperty(PropertyManager.PROPERTY_CHAT_SERVER_URL);
     String chatPage = PropertyManager.getProperty(PropertyManager.PROPERTY_CHAT_PORTAL_PAGE);
     remoteUser_ = securityContext.getRemoteUser();
+    String chatIntervalChat = PropertyManager.getProperty(PropertyManager.PROPERTY_INTERVAL_CHAT);
     String chatIntervalStatus = PropertyManager.getProperty(PropertyManager.PROPERTY_INTERVAL_STATUS);
     String chatIntervalNotif = PropertyManager.getProperty(PropertyManager.PROPERTY_INTERVAL_NOTIF);
     String plfUserStatusUpdateUrl = PropertyManager.getProperty(PropertyManager.PROPERTY_PLF_USER_STATUS_UPDATE_URL);
@@ -114,6 +115,7 @@ public class NotificationApplication
 
     return index.with().set("user", remoteUser_).set("token", token_)
             .set("chatServerURL", chatServerURL).set("chatPage", chatPage)
+            .set("chatIntervalChat", chatIntervalChat)
             .set("chatIntervalStatus", chatIntervalStatus)
             .set("chatIntervalNotif", chatIntervalNotif)
             .set("plfUserStatusUpdateUrl", plfUserStatusUpdateUrl)

--- a/application/src/main/java/org/exoplatform/chat/portlet/notification/templates/index.gtmpl
+++ b/application/src/main/java/org/exoplatform/chat/portlet/notification/templates/index.gtmpl
@@ -8,6 +8,7 @@
   data-chat-page="<%=chatPage%>"
   data-chat-server-url="<%=chatServerURL%>"
   data-plf-user-status-update-url="<%=plfUserStatusUpdateUrl%>"
+  data-chat-interval-chat="<%=chatIntervalChat%>"
   data-chat-interval-notif="<%=chatIntervalNotif%>"
   data-chat-interval-status="<%=chatIntervalStatus%>"
   data-space-id="<%=spaceId%>"

--- a/application/src/main/webapp/js/chat-modules.js
+++ b/application/src/main/webapp/js/chat-modules.js
@@ -1419,7 +1419,7 @@ function showMiniChatPopup(room, type) {
       var jzChatGetRoom = chatServerUrl+"/getRoom";
       var jzChatUpdateUnreadMessages = chatServerUrl+"/updateUnreadMessages";
       if (miniChats[index] === undefined) {
-        miniChats[index] = new ChatRoom(jzChatRead, jzChatSend, jzChatGetRoom, jzChatUpdateUnreadMessages,  "", "", 3000, false, dbName);
+        miniChats[index] = new ChatRoom(jzChatRead, jzChatSend, jzChatGetRoom, jzChatUpdateUnreadMessages,  "", "", chatNotification.chatIntervalChat, false, dbName);
         $miniChat.find(".message-input").keydown(function(event) {
           //prevent the default behavior of the enter button
           if ( event.which == 13 ) {

--- a/application/src/main/webapp/js/notif.js
+++ b/application/src/main/webapp/js/notif.js
@@ -54,6 +54,7 @@ ChatNotification.prototype.initOptions = function(options) {
   this.jzNotification = options.urlNotification;
   this.jzGetStatus = options.urlGetStatus;
   this.jzSetStatus = options.urlSetStatus;
+  this.chatIntervalChat = options.chatInterval;
   this.chatIntervalNotif = options.notificationInterval;
   this.chatIntervalStatus = options.statusInterval;
   this.dbName = options.dbName;
@@ -901,6 +902,7 @@ var chatNotification = new ChatNotification();
       "urlNotification": $notificationApplication.attr("data-chat-server-url")+"/notification",
       "urlGetStatus": $notificationApplication.attr("data-chat-server-url")+"/getStatus",
       "urlSetStatus": $notificationApplication.attr("data-chat-server-url")+"/setStatus",
+      "chatInterval": $notificationApplication.attr("data-chat-interval-chat"),
       "notificationInterval": $notificationApplication.attr("data-chat-interval-notif"),
       "statusInterval": $notificationApplication.attr("data-chat-interval-status"),
       "spaceId": $notificationApplication.attr("data-space-id"),

--- a/server/src/main/java/org/exoplatform/chat/utils/PropertyManager.java
+++ b/server/src/main/java/org/exoplatform/chat/utils/PropertyManager.java
@@ -141,11 +141,11 @@ public class PropertyManager {
       overridePropertyIfNotSet(PROPERTY_CHAT_SERVER_BASE, "");
       overridePropertyIfNotSet(PROPERTY_CHAT_SERVER_URL, "/chatServer");
       overridePropertyIfNotSet(PROPERTY_CHAT_PORTAL_PAGE, "/portal/intranet/chat");
-      overridePropertyIfNotSet(PROPERTY_INTERVAL_CHAT, "3000");
+      overridePropertyIfNotSet(PROPERTY_INTERVAL_CHAT, "5000");
       overridePropertyIfNotSet(PROPERTY_INTERVAL_SESSION, "60000");
-      overridePropertyIfNotSet(PROPERTY_INTERVAL_STATUS, "15000");
-      overridePropertyIfNotSet(PROPERTY_INTERVAL_NOTIF, "3000");
-      overridePropertyIfNotSet(PROPERTY_INTERVAL_USERS, "5000");
+      overridePropertyIfNotSet(PROPERTY_INTERVAL_STATUS, "60000");
+      overridePropertyIfNotSet(PROPERTY_INTERVAL_NOTIF, "5000");
+      overridePropertyIfNotSet(PROPERTY_INTERVAL_USERS, "60000");
       overridePropertyIfNotSet(PROPERTY_PASSPHRASE, "chat");
       overridePropertyIfNotSet(PROPERTY_CRON_NOTIF_CLEANUP, "0 0/60 * * * ?");
       overridePropertyIfNotSet(PROPERTY_PUBLIC_MODE, "false");


### PR DESCRIPTION
Increase default polling intervals to reduce server load.
Sample configuration files have already been changed in https://github.com/exo-addons/chat-application/commit/4a894ee6095365063dc360a8e0e84033891884b8.