### PR TITLE
CHAT-711 : return null in the API when the fetched room does not exist

### DIFF
--- a/server/src/main/java/org/exoplatform/chat/services/mongodb/UserMongoDataStorage.java
+++ b/server/src/main/java/org/exoplatform/chat/services/mongodb/UserMongoDataStorage.java
@@ -539,14 +539,16 @@ public class UserMongoDataStorage implements UserDataStorage {
 
   @Override
   public RoomBean getRoom(String user, String roomId, String dbName) {
-    RoomBean roomBean = new RoomBean();
-    roomBean.setRoom(roomId);
+    RoomBean roomBean = null;
     DBCollection coll = db(dbName).getCollection(M_ROOMS_COLLECTION);
     BasicDBObject query = new BasicDBObject();
     query.put("_id", roomId);
     DBCursor cursor = coll.find(query);
     if (cursor.hasNext())
     {
+      roomBean = new RoomBean();
+      roomBean.setRoom(roomId);
+
       DBObject doc = cursor.next();
       if (doc.containsField("timestamp"))
       {

--- a/server/src/test/java/org/exoplatform/chat/ChatTestCase.java
+++ b/server/src/test/java/org/exoplatform/chat/ChatTestCase.java
@@ -135,6 +135,21 @@ public class ChatTestCase extends AbstractChatTestCase
   }
 
   @Test
+  public void testWriteTextInNonExistingRoom() throws Exception
+  {
+    ChatService chatService = ServiceBootstrap.getChatService();
+    String roomId = "nonexistingroomid";
+
+    try {
+      chatService.write("foo", "john", roomId, "false", null);
+      fail("Sending a message in a non existing room should fail");
+    } catch (ChatException e) {
+      // expected exception
+      assertEquals(403, e.getStatus());
+    }
+  }
+
+  @Test
   public void testWriteJson() throws Exception
   {
     ChatService chatService = ServiceBootstrap.getChatService();


### PR DESCRIPTION
Return null in the API when the fetched room does not exist instead of returning an empty object.