### PR TITLE
SOC-5908 : update all status indicators on the profile page

### DIFF
--- a/application/src/main/webapp/js/chat.js
+++ b/application/src/main/webapp/js/chat.js
@@ -1157,7 +1157,7 @@
     this.isLoaded = true;
     this.hidePanel(".chat-sync-panel");
     this.hidePanel(".chat-login-panel");
-    chatNotification.changeStatusChat("offline");
+    chatNotification.changeStatusChat(this.username, "offline");
     this.showErrorPanel();
   };
 
@@ -1942,7 +1942,7 @@
           if (message.event == 'user-status-changed') {
             if (message.room == chatApplication.username) {
               // update current user status
-              chatNotification.changeStatusChat(message.data.status);
+              chatNotification.changeStatusChat(message.room, message.data.status);
             } else {
               // update rooms list
               chatApplication.rooms({type: 'u', user: message.room}).update({status: message.data.status});


### PR DESCRIPTION
Only status indicators of the current user where updated before. With this PR, any status indicator on the page are updated if they are related to the incoming websocket event.
When I say "any", it is actually the known one, which are the one in the menu of the profile page and the one in the profile page (below the menu).
The ugly thing about this IMO is that we have to target specifically these indicator, meaning it is totally coupled with the DOM and css classes used in Profile portlets. We should instead have a common UI component for the user status, and the user status should probably be managed in PLF (not only chat). But that's another story ;-)