### PR TITLE
CHAT-785 : update the message in memory after being edited to keep it sync between memory and display

### DIFF
--- a/application/src/main/webapp/js/chat.js
+++ b/application/src/main/webapp/js/chat.js
@@ -403,7 +403,7 @@
       }), function (publishAck) {
         if (publishAck.successful) {
           if (typeof callback === "function") {
-            callback();
+            callback(id, newMessage);
           }
         }
       });
@@ -3008,8 +3008,12 @@
         $uitext.val("");
         $('.edit-modal').modal('hide');
 
-        chatApplication.editMessage(id, message, function () {
+        chatApplication.editMessage(id, message, function (id, newMessage) {
           jqchat("#msg").focus();
+
+          // Update message in memory
+          chatApplication.chatRoom.messages.filter(function(message) { return message.msgId == id })
+              .forEach(function(message) { message.msg = newMessage });
         });
       });
 


### PR DESCRIPTION
When editing a message, the HTML content is updated but not the messages variable. Since CHAT-763, the edited message is taken from the messages variables (to avoid encoding issues). This PR updates the messages variable after a message has been updated.