### PR TITLE
CHAT-788 : use space id instead of space pretty name to get the space room

### DIFF
--- a/application/src/main/java/org/exoplatform/chat/portlet/notification/NotificationApplication.java
+++ b/application/src/main/java/org/exoplatform/chat/portlet/notification/NotificationApplication.java
@@ -114,7 +114,7 @@ public class NotificationApplication
     ResourceBundle bundle= applicationContext.resolveBundle(locale);
     String messages = bundleService_.getBundle("chatBundleData", bundle, locale);
     Space space = SpaceUtils.getSpaceByContext();
-    String spaceId = space == null ? StringUtils.EMPTY : space.getPrettyName();
+    String spaceId = space == null ? StringUtils.EMPTY : space.getId();
 
     String portalURI = Util.getPortalRequestContext().getPortalURI();
 


### PR DESCRIPTION
The issue is a regression of https://jira.exoplatform.org/browse/CHAT-782 which used the space pretty name instead of the space id. The room is fetched via its id, so this PR change it back to space id. 