### PR TITLE
CHAT-803 : update message in memory when a message is updated

### DIFF
--- a/application/src/main/webapp/js/chat.js
+++ b/application/src/main/webapp/js/chat.js
@@ -3031,10 +3031,6 @@
 
         chatApplication.editMessage(id, message, function (id, newMessage) {
           jqchat("#msg").focus();
-
-          // Update message in memory
-          chatApplication.chatRoom.messages.filter(function(message) { return message.msgId == id })
-              .forEach(function(message) { message.msg = newMessage });
         });
       });
 

--- a/application/src/main/webapp/js/chatRoom.js
+++ b/application/src/main/webapp/js/chatRoom.js
@@ -631,15 +631,25 @@
     }
   };
 
-  ChatRoom.prototype.updateMessage = function(message, withClientMsg) {
+  ChatRoom.prototype.updateMessage = function(updatedMessage, withClientMsg) {
     var $msg;
+    var messageId;
     if (withClientMsg) {
-      $msg = jqchat("#" + message.clientId);
+      messageId = updatedMessage.clientId;
     } else {
-      $msg = jqchat("#" + message.msgId);
+      messageId = updatedMessage.msgId;
     }
-    var out = this.generateMessageHTML(message);
+    $msg = jqchat("#" + messageId);
+    var out = this.generateMessageHTML(updatedMessage);
     $msg.replaceWith(out);
+
+    // Update message in memory
+    for(var i=0; i<this.messages.length; i++) {
+      if(this.messages[i].msgId == messageId) {
+        this.messages[i] = updatedMessage;
+        break;
+      }
+    }
   }
 
   /*


### PR DESCRIPTION
When a message is updated, the local list in memory is updated correctly but not the one in receivers' browsers. This PR updates the list in the updateMessage method to be sure it is well done in all cases.