### PR TITLE
CHAT-814 : remove only user token on logout, not the whole user object

### DIFF
--- a/common/src/main/java/org/exoplatform/chat/services/TokenService.java
+++ b/common/src/main/java/org/exoplatform/chat/services/TokenService.java
@@ -36,7 +36,7 @@ public interface TokenService
 
   void addUser(String user, String token, String dbName);
 
-  void removeUser(String user, String token, String dbName);
+  void removeUserToken(String user, String token, String dbName);
 
   Map<String, UserBean> getActiveUsersFilterBy(String user, List<String> limitUsers, String dbName, boolean withUsers, boolean withPublic, boolean isAdmin, int limit);
 

--- a/server-embedded/src/main/java/org/exoplatform/chat/server/ChatTools.java
+++ b/server-embedded/src/main/java/org/exoplatform/chat/server/ChatTools.java
@@ -78,15 +78,15 @@ public class ChatTools
   }
 
   @Resource
-  @Route("/removeUser")
-  public Response.Content removeUser(String username, String token, String passphrase, String dbName)
+  @Route("/removeUserToken")
+  public Response.Content removeUserToken(String username, String token, String passphrase, String dbName)
   {
     if (!checkPassphrase(passphrase))
     {
       return Response.notFound("{ \"message\": \"passphrase doesn't match\"}");
     }
 
-    tokenService.removeUser(username, token, dbName);
+    tokenService.removeUserToken(username, token, dbName);
     RealTimeMessageBean realTimeMessageBean = new RealTimeMessageBean(RealTimeMessageBean.EventType.TOKEN_INVALIDATED, null, username, new Date(), null);
     realTimeMessageService.sendMessage(realTimeMessageBean, username);
 

--- a/server-embedded/src/main/java/org/exoplatform/chat/services/TokenServiceImpl.java
+++ b/server-embedded/src/main/java/org/exoplatform/chat/services/TokenServiceImpl.java
@@ -64,9 +64,9 @@ public class TokenServiceImpl implements TokenService
     storage.addUser(user, token, dbName);
   }
 
-  public void removeUser(String user, String token, String dbName)
+  public void removeUserToken(String user, String token, String dbName)
   {
-    storage.removeUser(user, token, dbName);
+    storage.removeUserToken(user, token, dbName);
   }
 
   public Map<String, UserBean> getActiveUsersFilterBy(String user, List<String> limitUsers, String dbName, boolean withUsers, boolean withPublic, boolean isAdmin, int limit)

--- a/server-embedded/src/main/java/org/exoplatform/chat/services/TokenStorage.java
+++ b/server-embedded/src/main/java/org/exoplatform/chat/services/TokenStorage.java
@@ -30,7 +30,7 @@ public interface TokenStorage
 
   void addUser(String user, String token, String dbName);
 
-  void removeUser(String user, String token, String dbName);
+  void removeUserToken(String user, String token, String dbName);
 
   Map<String, UserBean> getActiveUsersFilterBy(String user, List<String> limitedFilter, String dbName, boolean withUsers, boolean withPublic, boolean isAdmin, int limit);
 }

--- a/server-embedded/src/main/java/org/exoplatform/chat/services/mongodb/TokenMongoService.java
+++ b/server-embedded/src/main/java/org/exoplatform/chat/services/mongodb/TokenMongoService.java
@@ -98,13 +98,16 @@ public class TokenMongoService implements TokenStorage
     }
   }
 
-  public void removeUser(String user, String token, String dbName)
+  public void removeUserToken(String user, String token, String dbName)
   {
     DBCollection coll = db(dbName).getCollection(M_USERS_COLLECTION);
     BasicDBObject query = new BasicDBObject();
     query.put("user", user);
     query.put("token", token);
-    coll.remove(query);
+    BasicDBObject tokenUpdate = new BasicDBObject();
+    tokenUpdate.put("token", "");
+    BasicDBObject set = new BasicDBObject("$set", tokenUpdate);
+    coll.update(query, set);
   }
 
   public Map<String, UserBean> getActiveUsersFilterBy(String user, List<String> limitedFilter, String dbName, boolean withUsers, boolean withPublic, boolean isAdmin, int limit)

--- a/services/src/main/java/org/exoplatform/addons/chat/listener/ServerBootstrap.java
+++ b/services/src/main/java/org/exoplatform/addons/chat/listener/ServerBootstrap.java
@@ -88,9 +88,9 @@ public class ServerBootstrap {
     postServer("addUser", "username="+username+"&token="+token+"&dbName="+dbName);
   }
 
-  public static void removeUser(String username, String token, String dbName)
+  public static void removeUserToken(String username, String token, String dbName)
   {
-    postServer("removeUser", "username="+username+"&token="+token+"&dbName="+dbName);
+    postServer("removeUserToken", "username="+username+"&token="+token+"&dbName="+dbName);
   }
 
   public static void setAsAdmin(String username, boolean isAdmin, String dbName)

--- a/services/src/main/java/org/exoplatform/addons/chat/listener/UpdateUserStatusListener.java
+++ b/services/src/main/java/org/exoplatform/addons/chat/listener/UpdateUserStatusListener.java
@@ -35,7 +35,7 @@ public class UpdateUserStatusListener extends Listener<ConversationRegistry, Con
                 // Remove user token from Chat Server
                 String token = ServerBootstrap.getToken(userId);
                 String dbName = ServerBootstrap.getDBName();
-                ServerBootstrap.removeUser(userId, token, dbName);
+                ServerBootstrap.removeUserToken(userId, token, dbName);
             }
         }
 


### PR DESCRIPTION
When a user does a logout, the listener org.exoplatform.addons.chat.listener.UpdateUserStatusListener did a complete removalof the user object in the database.
This user object contains the user information and the list of his team rooms and favorites.
Then at the next login, the user is recreated, but without any room or favorite.
This fix only clear the user token (to keep the fix for CHAT-787), not the whole user object.