### PR TITLE
CHAT-822 : display messages only once

### DIFF
--- a/application/src/main/webapp/js/chatRoom.js
+++ b/application/src/main/webapp/js/chatRoom.js
@@ -640,15 +640,19 @@
       messageId = updatedMessage.msgId;
     }
     $msg = jqchat("#" + messageId);
-    var out = this.generateMessageHTML(updatedMessage);
-    $msg.replaceWith(out);
+    if($msg) {
+      var out = this.generateMessageHTML(updatedMessage);
+      $msg.replaceWith(out);
 
-    // Update message in memory
-    for(var i=0; i<this.messages.length; i++) {
-      if(this.messages[i].msgId == messageId) {
-        this.messages[i] = updatedMessage;
-        return true;
+      // Update message in memory
+      if(updatedMessage.msgId) {
+        for (var i = 0; i < this.messages.length; i++) {
+          if (this.messages[i].msgId == updatedMessage.msgId) {
+            this.messages[i] = updatedMessage;
+          }
+        }
       }
+      return true;
     }
     return false;
   }
@@ -668,21 +672,23 @@
    * }
    */
   ChatRoom.prototype.addMessage = function(msg, checkToScroll) {
-    // A server message
     var updated = false;
+    // If it is a server message...
     if (msg.msgId) {
-      var messages = TAFFY(this.messages);
-      var tempMsg = messages({
-        clientId: msg.clientId
-      });
+      // Update local message with server message
+      if(msg.clientId) {
+        var messages = TAFFY(this.messages);
+        var tempMsg = messages({
+            clientId: msg.clientId
+        });
 
-      // Update local message with server message.
-      if (tempMsg.count() > 0) {
-        tempMsg.update(msg);
-        this.messages = messages().get();
-        updated = this.updateMessage(msg, true);
-        if (updated) {
-          return;
+        if (tempMsg.count() > 0) {
+          tempMsg.update(msg);
+          this.messages = messages().get();
+          updated = this.updateMessage(msg, true);
+          if (updated) {
+            return;
+          }
         }
       }
     } else {


### PR DESCRIPTION
When an user posts a message, it is first added in the room (client side) and then received via websocket from the server (with additional information). When it is received from the server, we check in the list of messages in memory to update it with the new version of the message received fro the server (based on the clientId).
The wrong id was used when updating the list of messages by the message received from the server, so the list was not updated. And in such a case, it considered it as a new message and displayed it again.
This fix uses the right id to update the list (updatedMessage.msgId).
Also, in the addMessage, the check is now done on msg.clientId instead of msg.msgId to know if it is a new message. Previously this check wasdone on msg.msgId (which existed) and then a search was done in messages based on the clientId, which was null. If there were another message with a null clientId in the list (which was the case when 2 messages were sent at the same time, as described in https://jira.exoplatform.org/browse/CHAT-816), it consideredthe message already existed and did not display the other one.