### PR TITLE
CHAT-825 : avoid automatic reconnection of websocket connection if it has been explicitly disconnected

### DIFF
--- a/application/src/main/webapp/js/chat.js
+++ b/application/src/main/webapp/js/chat.js
@@ -1751,6 +1751,7 @@
 
   ChatApplication.prototype.sessionTimeout = function() {
     requireChatCometd(function (cCometD) {
+      cCometD.explicitlyDisconnected = true;
       cCometD.disconnect();
     });
 

--- a/application/src/main/webapp/js/notif.js
+++ b/application/src/main/webapp/js/notif.js
@@ -828,9 +828,6 @@
   window.chatNotification = new ChatNotification();
 
   window.requireChatCometd = function(callback) {
-    if (chatNotification.tokenInvalidated) {
-      return;
-    }
     window.require(['SHARED/chatCometD'], function (cCometD) {
       if (chatNotification.standalone) {
         cCometD = cCometD.getInstance('chat');
@@ -883,8 +880,7 @@
         }
 
         // Do what you want with the message...
-        if (message.event == 'token-invalidated') {
-          chatNotification.tokenInvalidated = true;
+        if (message.event == 'logout-sent') {
           cCometD.disconnect();
         } else if (message.event == 'user-status-changed') {
           chatNotification.changeStatusChat(message.sender, message.data.status);


### PR DESCRIPTION
Even if the websocket connection is explicitly disconnected, when sending the next message the connection is automatically re-established.
This fix prevent this automatic reconnection is the disconnection has been explicitly requested. It always clear the credentials for more security.