### PR TITLE
MOB-2198: Adjust chat notification menu position

### DIFF
--- a/application/src/main/webapp/css/chatMobile.less
+++ b/application/src/main/webapp/css/chatMobile.less
@@ -427,4 +427,8 @@
       opacity: 1;
     }
   }
+  #chatApplicationNotification .dropdown-menu{
+    right: auto;
+    left: -345%;
+  }
 }


### PR DESCRIPTION
The chat notification menu is not well displayed on mobile. So I added to the drop-down menu "left" and "right" css properties to adjust its position.

I tried to adjust the width, but the drop-down menu contains fixed items about the user status in chat. It will add some white space that may affect display ergonomics.

Tested on: platform-5.2.x-edit-activities-comments-SNAPSHOT