### PR TITLE
Fix CHAT-1012: chat app is not opened when click on desktop notificat…

### DIFF
--- a/application/src/main/webapp/vue-app/desktopNotification.js
+++ b/application/src/main/webapp/vue-app/desktopNotification.js
@@ -163,11 +163,10 @@ function showDesktopNotif(path, msg) {
   } else {
     const isFirefox = typeof InstallTrigger !== 'undefined';
     const isLinux = navigator.platform.indexOf('Linux') >= 0;
-
     const clickHandler = function (notif) {
       notif.onclick = function () {
         document.dispatchEvent(new CustomEvent(chatConstants.ACTION_ROOM_SELECT, {'detail' : msg.room}));
-        window.focus();
+        window.open('/portal/intranet/chat','chatWindow').focus();
         notif.close();
       };
     };


### PR DESCRIPTION
Before this fix, the home page will be displayed when we click in message desktop notification. The right behavior is to open the chat tab. To fix that, we should open the chat application in new tab after clicking on the desktop notification. 